### PR TITLE
Adding custom node index column

### DIFF
--- a/examples/3D.ipynb
+++ b/examples/3D.ipynb
@@ -5,7 +5,7 @@
    "id": "a90e6ee8-422c-4c82-8945-a78ec51a4c28",
    "metadata": {},
    "source": [
-    "# 🪩 3D"
+    "# 🔮 3D"
    ]
   },
   {
@@ -121,7 +121,7 @@
     "    not_selected_color,\n",
     "    i=(0, len(atlas) - 1),\n",
     "):\n",
-    "    update_graph(i, selected_color)"
+    "    update_graph(i, selected_color, not_selected_color)"
    ]
   },
   {

--- a/examples/_index.ipynb
+++ b/examples/_index.ipynb
@@ -71,7 +71,7 @@
     "# Read more\n",
     "\n",
     "- [👟 Behaviors](./Behaviors.ipynb)\n",
-    "- [🪩 3D](./3D.ipynb)\n",
+    "- [🔮 3D](./3D.ipynb)\n",
     "- [🐛 Debugging with `FORCEGRAPH_DEBUG`](./FORCEGRAPH_DEBUG.ipynb)"
    ]
   }

--- a/examples/_index.ipynb
+++ b/examples/_index.ipynb
@@ -38,10 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using `ndarray`s\n",
-    "\n",
-    "We have some sample data in various formats. In its simplest form, `ForceGraph` will\n",
-    "only use NumPy `ndarray`s for its source data."
+    "We have some sample data in various formats. In its simplest form, `ForceGraph` will only use Pandas `DataFrame`s for its source data."
    ]
   },
   {

--- a/examples/_index.ipynb
+++ b/examples/_index.ipynb
@@ -30,7 +30,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "import ipyforcegraph.forcegraph"
+    "import ipyforcegraph.forcegraph\n",
+    "from ipyforcegraph.behaviors import NodeLabels"
    ]
   },
   {
@@ -58,7 +59,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fg = ipyforcegraph.forcegraph.ForceGraph()\n",
+    "fg = ipyforcegraph.forcegraph.ForceGraph(\n",
+    "    behaviors=[NodeLabels(column_name=\"id\")],\n",
+    ")\n",
+    "fg.source.node_id_column = \"id\"\n",
     "fg.source.nodes = pd.DataFrame.from_dict(data[\"nodes\"])\n",
     "fg.source.links = pd.DataFrame.from_dict(data[\"links\"])\n",
     "fg"

--- a/js/widgets/sources/dataframe.ts
+++ b/js/widgets/sources/dataframe.ts
@@ -30,7 +30,7 @@ export class DataFrameSourceModel extends WidgetModel {
       _model_name: DataFrameSourceModel.model_name,
       nodes: null,
       links: null,
-      node_id_column: null,
+      node_id_column: 'index',
       link_source_column: 'source',
       link_target_column: 'target',
     };

--- a/js/widgets/sources/dataframe.ts
+++ b/js/widgets/sources/dataframe.ts
@@ -30,8 +30,9 @@ export class DataFrameSourceModel extends WidgetModel {
       _model_name: DataFrameSourceModel.model_name,
       nodes: null,
       links: null,
-      link_source: 'source',
-      link_target: 'target',
+      node_id_column: null,
+      link_source_column: 'source',
+      link_target_column: 'target',
     };
   }
 
@@ -57,6 +58,7 @@ export class DataFrameSourceModel extends WidgetModel {
 
     const nodes = this.get('nodes');
     const links = this.get('links');
+    const nodeIdColumn = this.get('node_id_column');
     const sourceColumn = this.get('link_source_column');
     const targetColumn = this.get('link_target_column');
 
@@ -65,8 +67,10 @@ export class DataFrameSourceModel extends WidgetModel {
     const nodeCount = (nodes[nodeColumns[0]] || emptyArray).length;
     const linkCount = (links[sourceColumn] || emptyArray).length;
 
+    const indeces = nodes[nodeColumns[nodeIdColumn]] || [...Array(nodeCount).keys()]
+
     for (let id = 0; id < nodeCount; id++) {
-      let node = { id };
+      let node = { id: indeces[id] };
       for (const col of nodeColumns) {
         node[col] = nodes[col][id];
       }

--- a/js/widgets/sources/dataframe.ts
+++ b/js/widgets/sources/dataframe.ts
@@ -67,7 +67,7 @@ export class DataFrameSourceModel extends WidgetModel {
     const nodeCount = (nodes[nodeColumns[0]] || emptyArray).length;
     const linkCount = (links[sourceColumn] || emptyArray).length;
 
-    const indeces = nodes[nodeColumns[nodeIdColumn]] || [...Array(nodeCount).keys()]
+    const indeces = nodes[nodeColumns[nodeIdColumn]] || [...Array(nodeCount).keys()];
 
     for (let id = 0; id < nodeCount; id++) {
       let node = { id: indeces[id] };

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -178,7 +178,9 @@ ALL_TSCONFIG = [
 # tests
 EXAMPLES = ROOT / "examples"
 EXAMPLE_IPYNB = [
-    p for p in EXAMPLES.rglob("*.ipynb") if ".ipynb_checkpoints" not in str(p)
+    p
+    for p in EXAMPLES.rglob("*.ipynb")
+    if ".ipynb_checkpoints" not in str(p) and "untitled" not in str(p).lower()
 ]
 EXAMPLE_JSON = [
     p for p in EXAMPLES.rglob("*.json") if ".ipynb_checkpoints" not in str(p)

--- a/src/ipyforcegraph/forcegraph.py
+++ b/src/ipyforcegraph/forcegraph.py
@@ -20,7 +20,7 @@ class ForceGraph(W.DOMWidget, ForceBase):
     source: DataFrameSource = T.Instance(DataFrameSource, kw={}).tag(
         sync=True, **W.widget_serialization
     )
-    behaviors: list[Behavior] = W.TypedTuple(T.Instance(Behavior), kw={}).tag(
+    behaviors: tuple[Behavior] = W.TypedTuple(T.Instance(Behavior), kw={}).tag(
         sync=True, **W.widget_serialization
     )
 
@@ -35,6 +35,6 @@ class ForceGraph3D(W.DOMWidget, ForceBase):
     source: DataFrameSource = T.Instance(DataFrameSource, kw={}).tag(
         sync=True, **W.widget_serialization
     )
-    behaviors: list[Behavior] = W.TypedTuple(T.Instance(Behavior), kw={}).tag(
+    behaviors: tuple[Behavior] = W.TypedTuple(T.Instance(Behavior), kw={}).tag(
         sync=True, **W.widget_serialization
     )

--- a/src/ipyforcegraph/sources/dataframe.py
+++ b/src/ipyforcegraph/sources/dataframe.py
@@ -12,23 +12,31 @@ from ..serializers import dataframe_serialization
 
 @W.register
 class DataFrameSource(ForceBase):
+    """A Graph Source that stores the nodes and links as a pandas DataFrame."""
+
     _model_name: str = T.Unicode("DataFrameSourceModel").tag(sync=True)
-    nodes = TT.PandasType(klass=P.DataFrame, help="the DataFrame of node metadata").tag(
+
+    nodes: P.DataFrame = TT.PandasType(klass=P.DataFrame, help="the DataFrame of node metadata").tag(
         sync=True, **dataframe_serialization
     )
 
-    links = TT.PandasType(klass=P.DataFrame, help="the DataFrame of edge metadata").tag(
+    links: P.DataFrame = TT.PandasType(klass=P.DataFrame, help="the DataFrame of link metadata").tag(
         sync=True, **dataframe_serialization
     )
 
-    link_source_column = T.Unicode(
-        "source", help="the name of the column for an edge's source"
+    node_id_column: str = T.Unicode(
+        "index",
+        help="the name of the column for a node's identifier, 'index' uses the row number"
     ).tag(sync=True)
 
-    link_target_column = T.Unicode(
-        "target", help="the name of the column for an edge's target"
+    link_source_column: str = T.Unicode(
+        "source", help="the name of the column for a link's source"
+    ).tag(sync=True)
+
+    link_target_column: str = T.Unicode(
+        "target", help="the name of the column for a link's target"
     ).tag(sync=True)
 
     def __repr__(self):
         """A dumb repr to avoid string nasty pandas comparison stuff."""
-        return f"<{self.__class__.__name__}>"
+        return f"{self.__class__.__name__}({len(self.nodes)} nodes, {len(self.links)} links)"

--- a/src/ipyforcegraph/sources/dataframe.py
+++ b/src/ipyforcegraph/sources/dataframe.py
@@ -16,17 +16,17 @@ class DataFrameSource(ForceBase):
 
     _model_name: str = T.Unicode("DataFrameSourceModel").tag(sync=True)
 
-    nodes: P.DataFrame = TT.PandasType(klass=P.DataFrame, help="the DataFrame of node metadata").tag(
-        sync=True, **dataframe_serialization
-    )
+    nodes: P.DataFrame = TT.PandasType(
+        klass=P.DataFrame, help="the DataFrame of node metadata"
+    ).tag(sync=True, **dataframe_serialization)
 
-    links: P.DataFrame = TT.PandasType(klass=P.DataFrame, help="the DataFrame of link metadata").tag(
-        sync=True, **dataframe_serialization
-    )
+    links: P.DataFrame = TT.PandasType(
+        klass=P.DataFrame, help="the DataFrame of link metadata"
+    ).tag(sync=True, **dataframe_serialization)
 
     node_id_column: str = T.Unicode(
         "index",
-        help="the name of the column for a node's identifier, 'index' uses the row number"
+        help="the name of the column for a node's identifier, 'index' uses the row number",
     ).tag(sync=True)
 
     link_source_column: str = T.Unicode(


### PR DESCRIPTION
For @nrbgt 's consideration, not offended if we throw this away, just some thoughts.

# Changes
 - [x] Added a way to set the identifier column for the `nodes` 
 - [x] Replaced the `disco ball` emoji with the `crystal ball` 🔮 one (the disco one does not seem to render, at least on Windows/Firefox)
 - [x] make `nblint` ignore notebooks with `untitled` in the name (case insensitive)
 - [x] fixed the `_index.ipynb` to use the new `DataFrameSource`
 - [x] fixed the typing of the `behaviors` in the `ForceGraphs` from `list` to `tuple`