### PR TITLE
Fix serializers for `jupyterlab_widgets 3.0.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## `0.3.0` (unreleased)
+## `0.3.1`
+
+### `ipyforcegraph 0.3.1`
+
+- n/a
+
+### `@jupyrdf/jupyter-forcegraph 0.3.0`
+
+- fixes compatibility with `jupyterlab_widgets 3.0.6`
+
+## `0.3.0`
 
 ### `ipyforcegraph 0.3.0`
 

--- a/js/plugin.ts
+++ b/js/plugin.ts
@@ -37,7 +37,7 @@ const plugin: IPlugin<Application<Widget>, void> = {
         }
 
         loadingWidgets = new PromiseDelegate();
-        const { initializeZstd } = await import('./widgets/serializers');
+        const { initializeZstd } = await import('./widgets/serializers/dataframe');
         await initializeZstd();
 
         DEBUG && console.warn(`${EMOJI} loading widgets`);

--- a/js/widgets/behaviors/forces/dag.ts
+++ b/js/widgets/behaviors/forces/dag.ts
@@ -4,10 +4,9 @@
  */
 import { ForceGraphInstance } from 'force-graph/dist/force-graph';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce } from '../../../tokens';
 import { yes } from '../../../utils';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -16,10 +15,10 @@ export class DAGBehaviorModel extends FacetedForceModel implements IBehave, IFor
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    mode: { deserialize },
-    level_distance: { deserialize },
+    mode: widget_serialization,
+    level_distance: widget_serialization,
     // node template
-    node_filter: { deserialize },
+    node_filter: widget_serialization,
   };
 
   protected get _modelClass(): typeof DAGBehaviorModel {

--- a/js/widgets/behaviors/forces/force-center.ts
+++ b/js/widgets/behaviors/forces/force-center.ts
@@ -4,9 +4,8 @@
  */
 import { forceCenter as d3ForceCenter } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce, TAnyForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,9 +14,9 @@ export class CenterForceModel extends FacetedForceModel implements IBehave, IFor
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    x: { deserialize },
-    y: { deserialize },
-    z: { deserialize },
+    x: widget_serialization,
+    y: widget_serialization,
+    z: widget_serialization,
   };
 
   _force: d3ForceCenter;

--- a/js/widgets/behaviors/forces/force-cluster.ts
+++ b/js/widgets/behaviors/forces/force-cluster.ts
@@ -5,9 +5,8 @@
 import { default as d3ClusterForce } from 'd3-force-cluster-3d';
 import { NodeObject } from 'force-graph/dist/force-graph';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce, TAnyForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -34,15 +33,15 @@ export class ClusterForceModel extends FacetedForceModel implements IBehave, IFo
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    strength: { deserialize },
-    inertia: { deserialize },
+    strength: widget_serialization,
+    inertia: widget_serialization,
     // node template
-    key: { deserialize },
+    key: widget_serialization,
     // cluster template
-    radius: { deserialize },
-    y: { deserialize },
-    x: { deserialize },
-    z: { deserialize },
+    radius: widget_serialization,
+    y: widget_serialization,
+    x: widget_serialization,
+    z: widget_serialization,
   };
 
   _force: d3ClusterForce;

--- a/js/widgets/behaviors/forces/force-collision.ts
+++ b/js/widgets/behaviors/forces/force-collision.ts
@@ -4,9 +4,8 @@
  */
 import { forceCollide as d3ForceCollision } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,8 +14,8 @@ export class CollisionForceModel extends FacetedForceModel implements IBehave, I
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    radius: { deserialize },
-    strength: { deserialize },
+    radius: widget_serialization,
+    strength: widget_serialization,
   };
 
   _force: d3ForceCollision;

--- a/js/widgets/behaviors/forces/force-link.ts
+++ b/js/widgets/behaviors/forces/force-link.ts
@@ -5,9 +5,8 @@
 // import type d3Force from 'd3-force';
 import { forceLink as d3ForceLink } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -16,8 +15,8 @@ export class LinkForceModel extends FacetedForceModel implements IBehave, IForce
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    strength: { deserialize },
-    distance: { deserialize },
+    strength: widget_serialization,
+    distance: widget_serialization,
   };
 
   _force: d3ForceLink;

--- a/js/widgets/behaviors/forces/force-manybody.ts
+++ b/js/widgets/behaviors/forces/force-manybody.ts
@@ -4,9 +4,8 @@
  */
 import { forceManyBody as d3ForceManyBody } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,10 +14,10 @@ export class ManyBodyForceModel extends FacetedForceModel implements IBehave, IF
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    strength: { deserialize },
-    theta: { deserialize },
-    distance_max: { deserialize },
-    distance_min: { deserialize },
+    strength: widget_serialization,
+    theta: widget_serialization,
+    distance_max: widget_serialization,
+    distance_min: widget_serialization,
   };
 
   _force: d3ForceManyBody;

--- a/js/widgets/behaviors/forces/force-radial.ts
+++ b/js/widgets/behaviors/forces/force-radial.ts
@@ -4,9 +4,8 @@
  */
 import { forceRadial as d3ForceRadial } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,11 +14,11 @@ export class RadialForceModel extends FacetedForceModel implements IBehave, IFor
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    x: { deserialize },
-    y: { deserialize },
-    z: { deserialize },
-    radius: { deserialize },
-    strength: { deserialize },
+    x: widget_serialization,
+    y: widget_serialization,
+    z: widget_serialization,
+    radius: widget_serialization,
+    strength: widget_serialization,
   };
 
   _force: d3ForceRadial;

--- a/js/widgets/behaviors/forces/force-x.ts
+++ b/js/widgets/behaviors/forces/force-x.ts
@@ -4,9 +4,8 @@
  */
 import { forceX as d3XForce } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce, TAnyForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,8 +14,8 @@ export class XForceModel extends FacetedForceModel implements IBehave, IForce {
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    x: { deserialize },
-    strength: { deserialize },
+    x: widget_serialization,
+    strength: widget_serialization,
   };
 
   _force: d3XForce;

--- a/js/widgets/behaviors/forces/force-y.ts
+++ b/js/widgets/behaviors/forces/force-y.ts
@@ -4,9 +4,8 @@
  */
 import { forceY as d3YForce } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce, TAnyForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,8 +14,8 @@ export class YForceModel extends FacetedForceModel implements IBehave, IForce {
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    y: { deserialize },
-    strength: { deserialize },
+    y: widget_serialization,
+    strength: widget_serialization,
   };
 
   _force: d3YForce;

--- a/js/widgets/behaviors/forces/force-z.ts
+++ b/js/widgets/behaviors/forces/force-z.ts
@@ -4,9 +4,8 @@
  */
 import { forceZ as d3ZForce } from 'd3-force-3d';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, IForce, TAnyForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { FacetedForceModel } from './force';
 
@@ -15,8 +14,8 @@ export class ZForceModel extends FacetedForceModel implements IBehave, IForce {
 
   static serializers = {
     ...FacetedForceModel.serializers,
-    z: { deserialize },
-    strength: { deserialize },
+    z: widget_serialization,
+    strength: widget_serialization,
   };
 
   _force: d3ZForce;

--- a/js/widgets/behaviors/forces/force.ts
+++ b/js/widgets/behaviors/forces/force.ts
@@ -9,13 +9,10 @@ import type {
   NodeObject,
 } from 'force-graph/dist/force-graph';
 
-import {
-  IBackboneModelOptions,
-  WidgetModel,
-  unpack_models as deserialize,
-} from '@jupyter-widgets/base';
+import { IBackboneModelOptions, WidgetModel } from '@jupyter-widgets/base';
 
 import { DEBUG, EMOJI, EUpdate, IForce, TAnyForce } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 import { BehaviorModel, FacetedModel } from '../base';
 
 export type TForceRecord = Record<string, FacetedForceModel | null>;
@@ -80,7 +77,7 @@ export class GraphForcesModel extends BehaviorModel {
   static model_name = 'GraphForcesModel';
   static serializers = {
     ...WidgetModel.serializers,
-    forces: { deserialize },
+    forces: widget_serialization,
   };
 
   defaults() {

--- a/js/widgets/behaviors/graph-data.ts
+++ b/js/widgets/behaviors/graph-data.ts
@@ -2,11 +2,7 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import {
-  IBackboneModelOptions,
-  WidgetModel,
-  unpack_models as deserialize,
-} from '@jupyter-widgets/base';
+import { IBackboneModelOptions, WidgetModel } from '@jupyter-widgets/base';
 
 import {
   EUpdate,
@@ -15,6 +11,7 @@ import {
   IRenderOptions,
   WIDGET_DEFAULTS,
 } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 import { DataFrameSourceModel } from '../sources';
 
 import { BehaviorModel } from './base';
@@ -23,7 +20,7 @@ export class GraphDataModel extends BehaviorModel implements IBehave {
   static model_name = 'GraphDataModel';
   static serializers = {
     ...WidgetModel.serializers,
-    sources: { deserialize },
+    sources: widget_serialization,
   };
 
   protected _sourcesToCapture = 0;

--- a/js/widgets/behaviors/graph-image.ts
+++ b/js/widgets/behaviors/graph-image.ts
@@ -2,14 +2,11 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import {
-  IBackboneModelOptions,
-  WidgetModel,
-  unpack_models as deserialize,
-} from '@jupyter-widgets/base';
+import { IBackboneModelOptions, WidgetModel } from '@jupyter-widgets/base';
 import { ImageModel } from '@jupyter-widgets/controls';
 
 import { EMOJI, EUpdate, IBehave, IRenderOptions, WIDGET_DEFAULTS } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { BehaviorModel } from './base';
 
@@ -17,7 +14,7 @@ export class GraphImageModel extends BehaviorModel implements IBehave {
   static model_name = 'GraphImageModel';
   static serializers = {
     ...WidgetModel.serializers,
-    frames: { deserialize },
+    frames: widget_serialization,
   };
 
   protected _framesToCapture = 0;

--- a/js/widgets/behaviors/link-arrow.ts
+++ b/js/widgets/behaviors/link-arrow.ts
@@ -2,9 +2,8 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, ILinkBehaveOptions } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { FacetedModel } from './base';
 
@@ -13,9 +12,9 @@ export class LinkArrowModel extends FacetedModel implements IBehave {
 
   static serializers = {
     ...FacetedModel.serializers,
-    length: { deserialize },
-    color: { deserialize },
-    relative_position: { deserialize },
+    length: widget_serialization,
+    color: widget_serialization,
+    relative_position: widget_serialization,
   };
 
   protected get _modelClass(): typeof LinkArrowModel {

--- a/js/widgets/behaviors/link-particles.ts
+++ b/js/widgets/behaviors/link-particles.ts
@@ -2,9 +2,8 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, ILinkBehaveOptions } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { FacetedModel } from './base';
 
@@ -13,10 +12,10 @@ export class LinkParticleModel extends FacetedModel implements IBehave {
 
   static serializers = {
     ...FacetedModel.serializers,
-    color: { deserialize },
-    density: { deserialize },
-    speed: { deserialize },
-    width: { deserialize },
+    color: widget_serialization,
+    density: widget_serialization,
+    speed: widget_serialization,
+    width: widget_serialization,
   };
 
   protected get _modelClass(): typeof LinkParticleModel {

--- a/js/widgets/behaviors/link-shape.ts
+++ b/js/widgets/behaviors/link-shape.ts
@@ -2,9 +2,8 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, ILinkBehaveOptions } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { FacetedModel } from './base';
 
@@ -13,8 +12,8 @@ export class LinkShapeModel extends FacetedModel implements IBehave {
 
   static serializers = {
     ...FacetedModel.serializers,
-    width: { deserialize },
-    color: { deserialize },
+    width: widget_serialization,
+    color: widget_serialization,
   };
 
   protected get _modelClass(): typeof LinkShapeModel {

--- a/js/widgets/behaviors/link-tooltip.ts
+++ b/js/widgets/behaviors/link-tooltip.ts
@@ -2,9 +2,8 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, ILinkBehaveOptions } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { FacetedModel } from './base';
 
@@ -13,7 +12,7 @@ export class LinkTooltipModel extends FacetedModel implements IBehave {
 
   static serializers = {
     ...FacetedModel.serializers,
-    label: { deserialize },
+    label: widget_serialization,
   };
 
   protected get _modelClass(): typeof LinkTooltipModel {

--- a/js/widgets/behaviors/node-shape.ts
+++ b/js/widgets/behaviors/node-shape.ts
@@ -4,10 +4,7 @@
  */
 import type THREE from 'three';
 
-import {
-  IBackboneModelOptions,
-  unpack_models as deserialize,
-} from '@jupyter-widgets/base';
+import { IBackboneModelOptions } from '@jupyter-widgets/base';
 
 import {
   EUpdate,
@@ -17,6 +14,7 @@ import {
   INodeThreeBehaveOptions,
   emptyArray,
 } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { BehaviorModel, FacetedModel } from './base';
 import type { ShapeBaseModel } from './shapes/base';
@@ -25,8 +23,8 @@ export class NodeShapeFacetsModel extends FacetedModel implements IBehave {
   static model_name = 'NodeShapeFacetsModel';
   static serializers = {
     ...BehaviorModel.serializers,
-    size: { deserialize },
-    color: { deserialize },
+    size: widget_serialization,
+    color: widget_serialization,
   };
 
   get _facetClass(): typeof NodeShapeFacetsModel {
@@ -46,7 +44,7 @@ export class NodeShapeModel extends NodeShapeFacetsModel implements IBehave {
   static model_name = 'NodeShapeModel';
   static serializers = {
     ...NodeShapeFacetsModel.serializers,
-    shapes: { deserialize },
+    shapes: widget_serialization,
   };
 
   defaults() {

--- a/js/widgets/behaviors/node-tooltip.ts
+++ b/js/widgets/behaviors/node-tooltip.ts
@@ -2,9 +2,8 @@
  * Copyright (c) 2023 ipyforcegraph contributors.
  * Distributed under the terms of the Modified BSD License.
  */
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { IBehave, INodeBehaveOptions } from '../../tokens';
+import { widget_serialization } from '../serializers/widget';
 
 import { FacetedModel } from './base';
 
@@ -13,7 +12,7 @@ export class NodeTooltipModel extends FacetedModel implements IBehave {
 
   static serializers = {
     ...FacetedModel.serializers,
-    label: { deserialize },
+    label: widget_serialization,
   };
 
   protected get _modelClass(): typeof NodeTooltipModel {

--- a/js/widgets/behaviors/shapes/base.ts
+++ b/js/widgets/behaviors/shapes/base.ts
@@ -1,12 +1,11 @@
 import type THREE from 'three';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import {
   EMOJI,
   INodeCanvasBehaveOptions,
   INodeThreeBehaveOptions,
 } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 import { FacetedModel } from '../base';
 
 /*
@@ -140,14 +139,14 @@ export class GeometryShapeModel extends ShapeBaseModel {
 
   static serializers = {
     ...ShapeBaseModel.serializers,
-    width: { deserialize },
-    height: { deserialize },
-    depth: { deserialize },
-    fill: { deserialize },
-    opacity: { deserialize },
-    stroke: { deserialize },
-    stroke_width: { deserialize },
-    scale_on_zoom: { deserialize },
+    width: widget_serialization,
+    height: widget_serialization,
+    depth: widget_serialization,
+    fill: widget_serialization,
+    opacity: widget_serialization,
+    stroke: widget_serialization,
+    stroke_width: widget_serialization,
+    scale_on_zoom: widget_serialization,
   };
 
   protected get shapeDefaults(): IDimensionOptions {

--- a/js/widgets/behaviors/shapes/text.ts
+++ b/js/widgets/behaviors/shapes/text.ts
@@ -4,9 +4,8 @@
  */
 import type SpriteText from 'three-spritetext';
 
-import { unpack_models as deserialize } from '@jupyter-widgets/base';
-
 import { INodeCanvasBehaveOptions, INodeThreeBehaveOptions } from '../../../tokens';
+import { widget_serialization } from '../../serializers/widget';
 
 import { IBaseOptions, ITextOptions, ShapeBaseModel, TEXT_DEFAULTS } from './base';
 
@@ -19,15 +18,15 @@ export class TextShapeModel extends ShapeBaseModel {
 
   static serializers = {
     ...ShapeBaseModel.serializers,
-    text: { deserialize },
-    font: { deserialize },
-    size: { deserialize },
-    fill: { deserialize },
-    stroke: { deserialize },
-    stroke_width: { deserialize },
-    background: { deserialize },
-    padding: { deserialize },
-    scale_on_zoom: { deserialize },
+    text: widget_serialization,
+    font: widget_serialization,
+    size: widget_serialization,
+    fill: widget_serialization,
+    stroke: widget_serialization,
+    stroke_width: widget_serialization,
+    background: widget_serialization,
+    padding: widget_serialization,
+    scale_on_zoom: widget_serialization,
   };
 
   drawNode2D(options: INodeCanvasBehaveOptions): void {

--- a/js/widgets/display/2d.ts
+++ b/js/widgets/display/2d.ts
@@ -19,7 +19,6 @@ import {
   DOMWidgetView,
   IBackboneModelOptions,
   WidgetView,
-  unpack_models as deserialize,
 } from '@jupyter-widgets/base';
 
 import {
@@ -55,13 +54,14 @@ import {
   emptyArray,
 } from '../../tokens';
 import { DAGBehaviorModel, FacetedForceModel, GraphForcesModel } from '../behaviors';
+import { widget_serialization } from '../serializers/widget';
 
 export class ForceGraphModel extends DOMWidgetModel {
   static model_name = 'ForceGraphModel';
   static serializers = {
     ...DOMWidgetModel.serializers,
-    source: { deserialize },
-    behaviors: { deserialize },
+    source: widget_serialization,
+    behaviors: widget_serialization,
   };
 
   protected _nodeBehaviorsByMethod: TNodeMethodMap;

--- a/js/widgets/serializers/dataframe.ts
+++ b/js/widgets/serializers/dataframe.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 
 import { IWidgetManager, WidgetModel } from '@jupyter-widgets/base';
 
-import { DEBUG, EMOJI } from '../tokens';
+import { DEBUG, EMOJI } from '../../tokens';
 
 export interface IReceivedSerializedDataFrame {
   buffer: DataView;

--- a/js/widgets/serializers/index.ts
+++ b/js/widgets/serializers/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2023 ipyforcegraph contributors.
+ * Distributed under the terms of the Modified BSD License.
+ */
+export * from './dataframe';
+export * from './widget';

--- a/js/widgets/serializers/widget.ts
+++ b/js/widgets/serializers/widget.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 ipyforcegraph contributors.
+ * Distributed under the terms of the Modified BSD License.
+ */
+import { WidgetModel, unpack_models } from '@jupyter-widgets/base';
+
+export const widget_serialization = {
+  deserialize: unpack_models,
+  serialize: (models: WidgetModel[]): string[] => {
+    const modelIds: string[] = [];
+    for (const model of models) {
+      modelIds.push(`IPY_MODEL_${model.model_id}`);
+    }
+    return modelIds;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyrdf/jupyter-forcegraph",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "force-graph widget for Jupyter",
   "license": "BSD-3-Clause",
   "author": "ipyforcegraph contributors",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "ipyforcegraph"
-version = "0.3.0"
+version = "0.3.1"
 description = "2D and 3D force-directed graph widgets for Jupyter"
 readme = "README.md"
 authors = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,21 +12,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        use: [
-          {
-            'loader': 'source-map-loader',
-            options: {
-              filterSourceMappingUrl: (url, resourcePath) => {
-                if (resourcePath.includes('@bokuweb/zstd-wasm')) {
-                  // doesn't ship `/lib`
-                  return false;
-                }
-                return true;
-              },
-            },
-
-          }
-        ],
+        use: 'source-map-loader',
       },
       {
         test: /zstd\.wasm/,
@@ -34,4 +20,5 @@ module.exports = {
       },
     ],
   },
+  ignoreWarnings: [/Failed to parse source map/],
 };


### PR DESCRIPTION
## References

- fixes #71

## Code changes

- backports substantive changes from #68

## User-facing changes

- widgets should work with the latest `ipywidgets` and `jupyterlab_widgets`

## Backwards-incompatible changes

- n/a
  - or rather, we're _hoping_ by running this against the previous locked versions